### PR TITLE
Fix a couple of issues when NoClass is turned on in HTML Options

### DIFF
--- a/src/PygmentSharp/PygmentSharp.Core/Formatting/HtmlFormatter.cs
+++ b/src/PygmentSharp/PygmentSharp.Core/Formatting/HtmlFormatter.cs
@@ -427,7 +427,7 @@ pre {{ line-height: 125%; }}
                         ttype = ttype.Parent;
                         cclass = getcls(ttype);
                     }
-                    cspan = $"<span style=\"{c2s[cclass].StyleRules}\">";
+                    cspan = !string.IsNullOrEmpty(cclass) ? $"<span style=\"{c2s[cclass].StyleRules}\">" : "";
 
                 }
                 else

--- a/src/PygmentSharp/PygmentSharp.Core/Formatting/HtmlFormatter.cs
+++ b/src/PygmentSharp/PygmentSharp.Core/Formatting/HtmlFormatter.cs
@@ -315,8 +315,8 @@ pre {{ line-height: 125%; }}
             {
                 yield return new WrapResult(false, $"<table class=\"{Options.CssClass}table\">" +
                                                    "<tr><td><div class=\"linenodiv\"" +
-                                                   "style=\"background-color: #f0f0f0; padding-right: 10px\">\"" +
-                                                   "<pre style=\"line-height: 125%\">\"" +
+                                                   "style=\"background-color: #f0f0f0; padding-right: 10px\">" +
+                                                   "<pre style=\"line-height: 125%\">" +
                                                    ls + "</pre></div></td><td class=\"code\">");
             }
             else


### PR DESCRIPTION
When using the HTML formatter and the NoClass parameter is turned on, there are two issues.

- An error is thrown when it is creating the span with the style, if a style can't be found for the token type.
- There are a couple of extra quotes in the line numbers table when line numbers is turned on.

These two issues are fixed in this PR